### PR TITLE
Add handling of PathTooLongException in FindFiles()

### DIFF
--- a/SharpUp/Program.cs
+++ b/SharpUp/Program.cs
@@ -428,6 +428,7 @@ namespace SharpUp
                         files.AddRange(FindFiles(directory, pattern));
                 }
                 catch (UnauthorizedAccessException) { }
+                catch (PathTooLongException) { }
             }
 
             return files;


### PR DESCRIPTION
Happens when the generated path (path+pattern) is too long