### PR TITLE
Added PrivEsc tasks: WriteDacl and WriteRegistryAutorun. Added more verbose output for file and service access rights

### DIFF
--- a/SharpUp/Program.cs
+++ b/SharpUp/Program.cs
@@ -842,19 +842,18 @@ namespace SharpUp
             {
                 Console.WriteLine("\r\n\r\n=== Unattended Install Files ===\r\n");
 
-                string drive = System.Environment.GetEnvironmentVariable("SystemDrive");
-
+                string windir = System.Environment.GetEnvironmentVariable("windir");
                 string[] SearchLocations =
                 {
-                    String.Format("{0}\\sysprep\\sysprep.xml", drive),
-                    String.Format("{0}\\sysprep\\sysprep.inf", drive),
-                    String.Format("{0}\\sysprep.inf", drive),
-                    String.Format("{0}\\Panther\\Unattended.xml", drive),
-                    String.Format("{0}\\Panther\\Unattend.xml", drive),
-                    String.Format("{0}\\Panther\\Unattend\\Unattend.xml", drive),
-                    String.Format("{0}\\Panther\\Unattend\\Unattended.xml", drive),
-                    String.Format("{0}\\System32\\Sysprep\\unattend.xml", drive),
-                    String.Format("{0}\\System32\\Sysprep\\Panther\\unattend.xml", drive)
+                    String.Format("{0}\\sysprep\\sysprep.xml", windir),
+                    String.Format("{0}\\sysprep\\sysprep.inf", windir),
+                    String.Format("{0}\\sysprep.inf", windir),
+                    String.Format("{0}\\Panther\\Unattended.xml", windir),
+                    String.Format("{0}\\Panther\\Unattend.xml", windir),
+                    String.Format("{0}\\Panther\\Unattend\\Unattend.xml", windir),
+                    String.Format("{0}\\Panther\\Unattend\\Unattended.xml", windir),
+                    String.Format("{0}\\System32\\Sysprep\\unattend.xml", windir),
+                    String.Format("{0}\\System32\\Sysprep\\Panther\\unattend.xml", windir)
                 };
 
                 foreach (string SearchLocation in SearchLocations)
@@ -1210,6 +1209,7 @@ namespace SharpUp
             GetMcAfeeSitelistFiles();
             GetCachedGPPPassword();
         }
+        
 
 
         //https://bytecode77.com/hacking/exploits/uac-bypass/slui-file-handler-hijack-privilege-escalation
@@ -1321,6 +1321,7 @@ namespace SharpUp
             }
         }
 
+
         static void Main(string[] args)
         {
             bool auditMode = args.Contains("audit", StringComparer.CurrentCultureIgnoreCase);
@@ -1335,21 +1336,28 @@ namespace SharpUp
                 }
                 else
                 {
-                    System.Console.WriteLine("Usage: SharpView.exe WriteRegistryAutorun <service>");
+                    System.Console.WriteLine("Usage: SharpView.exe WriteDacl <service>");
 
                 }
             }
             else if (args.Contains("WriteRegistry", StringComparer.CurrentCultureIgnoreCase))
             {
+
+                foreach (string arg in args)
+                {
+                    System.Console.WriteLine(arg);
+                }
+
                 if (args.Length == 5)
                 {
                     WriteRegistry(hiveBase: args[1], subKey: args[2], name: args[3], command: args[4]);
                 }
-
                 else
                 {
-                    System.Console.WriteLine("USage: SharpView.exe WriteRegistryAutorun <CurrentUser|LocalMachine> <subkey> <name> <command>");
+                    System.Console.WriteLine("USage: SharpUp.exe WriteRegistryAutorun <CurrentUser|LocalMachine> <subkey> <name> <command>");
                     System.Console.WriteLine("======Hint: Local Machine AutoRun Locations=====");
+               
+
                     string[] autorunLocations = new string[] {
                         @"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run",
                         @"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\RunOnce",
@@ -1366,7 +1374,7 @@ namespace SharpUp
                     }
                 }
             }
-            else if (args.Contains("ListAutoruns", StringComparer.CurrentCultureIgnoreCase))
+              else if (args.Contains("ListAutoruns", StringComparer.CurrentCultureIgnoreCase))
             {
                 ListAutoruns();
             }

--- a/SharpUp/Program.cs
+++ b/SharpUp/Program.cs
@@ -841,19 +841,18 @@ namespace SharpUp
             {
                 Console.WriteLine("\r\n\r\n=== Unattended Install Files ===\r\n");
 
-                string drive = System.Environment.GetEnvironmentVariable("SystemDrive");
-
+                string windir = System.Environment.GetEnvironmentVariable("windir");
                 string[] SearchLocations =
                 {
-                    String.Format("{0}\\sysprep\\sysprep.xml", drive),
-                    String.Format("{0}\\sysprep\\sysprep.inf", drive),
-                    String.Format("{0}\\sysprep.inf", drive),
-                    String.Format("{0}\\Panther\\Unattended.xml", drive),
-                    String.Format("{0}\\Panther\\Unattend.xml", drive),
-                    String.Format("{0}\\Panther\\Unattend\\Unattend.xml", drive),
-                    String.Format("{0}\\Panther\\Unattend\\Unattended.xml", drive),
-                    String.Format("{0}\\System32\\Sysprep\\unattend.xml", drive),
-                    String.Format("{0}\\System32\\Sysprep\\Panther\\unattend.xml", drive)
+                    String.Format("{0}\\sysprep\\sysprep.xml", windir),
+                    String.Format("{0}\\sysprep\\sysprep.inf", windir),
+                    String.Format("{0}\\sysprep.inf", windir),
+                    String.Format("{0}\\Panther\\Unattended.xml", windir),
+                    String.Format("{0}\\Panther\\Unattend.xml", windir),
+                    String.Format("{0}\\Panther\\Unattend\\Unattend.xml", windir),
+                    String.Format("{0}\\Panther\\Unattend\\Unattended.xml", windir),
+                    String.Format("{0}\\System32\\Sysprep\\unattend.xml", windir),
+                    String.Format("{0}\\System32\\Sysprep\\Panther\\unattend.xml", windir)
                 };
 
                 foreach (string SearchLocation in SearchLocations)

--- a/SharpUp/Program.cs
+++ b/SharpUp/Program.cs
@@ -1242,7 +1242,7 @@ namespace SharpUp
                 }
                 else
                 {
-                    System.Console.WriteLine("Usage: SharpView.exe WriteRegistryAutorun <service>");
+                    System.Console.WriteLine("Usage: SharpView.exe WriteDacl <service>");
 
                 }
             }


### PR DESCRIPTION
Not sure if you want to add PrivEsc tasks into this, or just leave it as detection only. I wrote up a few privescs and persistence tasks I needed for an engagement and so am sharing. Added registry autorun and service dacl writes.

For example to write a registry key:
```
SharpUp.exe WriteRegistry CurrentUser "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run" testing123
USage: SharpView.exe WriteRegistryAutorun <CurrentUser|LocalMachine> <subkey> <name> <command>
======Hint: Local Machine AutoRun Locations=====
SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run
SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\RunOnce
SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Run
SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\RunOnce
SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\RunService
SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\RunOnceService
SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\RunService
SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\RunOnceService
```
Working command: 
`SharpUp.exe WriteRegistry CurrentUser "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run" blah testcd
`

Also made the output of some of the checks more verbose so it is easy to see what specific modify rights are granted on a file, folder, or service. Addressed #12  by printing the ACEType in the output now. 

Pretty hacky, but the tweaks have been helpful for us so far. If they are too rough in their current state to merge in, I can submit again once they are more polished and more privescs added. 