### PR TITLE
Check the user SID on current ACE

### DIFF
--- a/SharpUp/Program.cs
+++ b/SharpUp/Program.cs
@@ -391,7 +391,7 @@ namespace SharpUp
 
                     foreach (FileSystemAccessRule rule in rules)
                     {
-                        if (identity.Groups.Contains(rule.IdentityReference))
+                        if (identity.Groups.Contains(rule.IdentityReference) || rule.IdentityReference == identity.User)
                         {
                             foreach (FileSystemRights AccessRight in ModifyRights)
                             {
@@ -656,7 +656,7 @@ namespace SharpUp
 
                     foreach (System.Security.AccessControl.CommonAce ace in dacl)
                     {
-                        if (identity.Groups.Contains(ace.SecurityIdentifier))
+                        if (identity.Groups.Contains(ace.SecurityIdentifier) || ace.SecurityIdentifier == identity.User)
                         {
                             ServiceAccessRights serviceRights = (ServiceAccessRights)ace.AccessMask;
                             foreach (ServiceAccessRights ModifyRight in ModifyRights)


### PR DESCRIPTION
Privileges on the file system or on the service are currently verified via the SIDs of the groups of the current user:
`if (identity.Groups.Contains(rule.IdentityReference))`

The SID of the current user is not contained within the variable "Identidy.groups". 
So if an ACE is set up with the current user, it will not be detected by SharpUp.

Let me know if I'm misunderstanding something here :)