### PR TITLE
Added unquoted service path search

### DIFF
--- a/SharpUp/Program.cs
+++ b/SharpUp/Program.cs
@@ -747,7 +747,7 @@ namespace SharpUp
                         string check_path = new_path.Substring(0, new_path.LastIndexOf('\\')) + "\\";
                         if (CheckModifiableAccess(check_path, true))
                         {
-                            if (!modPaths.Contains(check_path))
+                            if (!modPaths.Contains(new_path))
                             {
                                 modPaths.Add(new_path);
                             }

--- a/SharpUp/Program.cs
+++ b/SharpUp/Program.cs
@@ -486,6 +486,7 @@ namespace SharpUp
                             Console.WriteLine("  State            : {0}", result["State"]);
                             Console.WriteLine("  StartMode        : {0}", result["StartMode"]);
                             Console.WriteLine("  PathName         : {0}", result["PathName"]);
+                            Console.WriteLine();
                         }
                     }
                 }
@@ -693,6 +694,7 @@ namespace SharpUp
                                         Console.WriteLine("  State            : {0}", result["State"]);
                                         Console.WriteLine("  StartMode        : {0}", result["StartMode"]);
                                         Console.WriteLine("  PathName         : {0}", result["PathName"]);
+                                        Console.WriteLine();
                                     }
                                     break;
                                 }
@@ -1056,6 +1058,7 @@ namespace SharpUp
                     Console.WriteLine("NewName: {0}", NewName);
                     Console.WriteLine("cPassword: {0}", cPassword);
                     Console.WriteLine("Changed: {0}", Changed);
+                    Console.WriteLine();
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
I added a check for unquoted service paths since that's what I most commonly see.  It only reports the vulnerable service if one of the hijackable locations are able to have a file written to them.  To determine the difference between a CreateFile and CreateDirectory, I had to modify the CheckModifiableAccess function and provide an overloaded function to only check for file-level access.  This avoids the false positives that PowerUp used to report on the permission to make a folder in the C:\ drive.

Let me know if you have any questions