### PR TITLE
`TokenPrivileges` leaks memory for token info

### DIFF
--- a/SharpUp/Checks/TokenPrivileges.cs
+++ b/SharpUp/Checks/TokenPrivileges.cs
@@ -51,6 +51,7 @@ namespace SharpUp.Checks
                     Marshal.FreeHGlobal(LuidPointer);
                 }
             }
+            Marshal.FreeHGlobal(TokenInformation);
         }
     }
 }


### PR DESCRIPTION
Add a call to `Marshal.FreeHGlobal` to free the memory