### PR TITLE
Remove minimum requirement for C# version 7

### DIFF
--- a/SharpUp/Checks/CachedGPPPassword.cs
+++ b/SharpUp/Checks/CachedGPPPassword.cs
@@ -37,7 +37,8 @@ namespace SharpUp.Checks
                     {
                         continue; // uninteresting XML files, move to next
                     }
-                    if (ParseGPPPasswordFromXml(file, out GPPPassword result))
+                    GPPPassword result;
+                    if (ParseGPPPasswordFromXml(file, out result))
                     {
                         _isVulnerable = true;
                         _details.Add(result.ToString());

--- a/SharpUp/Checks/DomainGPPPassword.cs
+++ b/SharpUp/Checks/DomainGPPPassword.cs
@@ -31,7 +31,8 @@ namespace SharpUp.Checks
                             file.Contains("Printers.xml") ||
                             file.Contains("Drives.xml"))
                         {
-                            if (ParseGPPPasswordFromXml(file, out GPPPassword result))
+                            GPPPassword result;
+                            if (ParseGPPPasswordFromXml(file, out result))
                             {
                                 _isVulnerable = true;
                                 _details.Add(result.ToString());


### PR DESCRIPTION
Adding explicit variable declarations for an out variable, instead of declaring them in the method call means that C# version 7 is not a minimum requirement, and different version of msbuild can be used. So this PR improves backward compatibility with earlier C# versions.

"Starting with C# 7.0, you can declare the out variable in the argument list of the method call, rather than in a separate variable declaration. " - https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/out-parameter-modifier